### PR TITLE
Add client_id option to populate X-SwiftNav-Client-Id header

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ The `ntripping` utility has the following usage:
         -v, --verbose
 
     OPTIONS:
-            --height <height>     [default: -5.549358852471994]
-            --lat <lat>           [default: 37.77101999622968]
-            --lon <lon>           [default: -122.40315159140708]
-            --url <url>           [default: na.skylark.swiftnav.com:2101/CRS]
+            --client-id <client-id> [default: 00000000-0000-0000-0000-000000000000]
+            --height <height>       [default: -5.549358852471994]
+            --lat <lat>             [default: 37.77101999622968]
+            --lon <lon>             [default: -122.40315159140708]
+            --url <url>             [default: na.skylark.swiftnav.com:2101/CRS]
 
 Different resources can be requested from different locations. By default, a San
 Francisco latitude, longitude, and height will be used.

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,9 @@ struct Opt {
     #[structopt(long, default_value = "-5.549358852471994")]
     height: String,
 
+    #[structopt(long, default_value = "00000000-0000-0000-0000-000000000000")]
+    client_id: String,
+
     #[structopt(short, long)]
     verbose: bool,
 }
@@ -68,8 +71,12 @@ fn main() -> Result<()> {
         let mut curl = curl.borrow_mut();
 
         let mut headers = List::new();
+        let mut client_id_header = "X-SwiftNav-Client-Id: ".to_string();
+        client_id_header.push_str(&opt.client_id);
+
         headers.append("Transfer-Encoding:")?;
         headers.append("Ntrip-Version: Ntrip/2.0")?;
+        headers.append(&client_id_header)?;
 
         curl.http_headers(headers)?;
         curl.useragent("NTRIP ntrip-client/1.0")?;


### PR DESCRIPTION
We are planning to add an additional header to identify clients, it
would be nice to have it here as well. It will be ignored if the castor
doesn't support it.

Example usage:
```
ntripping --url http://username:*****@localhost:5000/CRS \
      --client-id $(ioreg -d2 -c IOPlatformExpertDevice | awk -F\" '/IOPlatformUUID/{print $(NF-1)}')
```

```
GET /CRS HTTP/1.1
Host: localhost:5000
Authorization: Basic *****
User-Agent: NTRIP ntrip-client/1.0
Accept: */*
Ntrip-Version: Ntrip/2.0
X-SwiftNav-Client-Id: 526D6616-B75D-50B3-827B-7A67857CAF4D
Expect: 100-continue
```