### PR TITLE
Remove use of unsafe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,8 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bac9f84ca0977c4d9b8db998689de55b9e976656a6bc87fada2ca710d504c7"
+version = "0.4.43"
+source = "git+https://github.com/alexcrichton/curl-rust.git?branch=main#16133f713af1e5493a5141b87edb939343d7ee73"
 dependencies = [
  "curl-sys",
  "libc",
@@ -101,8 +100,7 @@ dependencies = [
 [[package]]
 name = "curl-sys"
 version = "0.4.54+curl-7.83.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25debbc3365c3e7ee79e30918df5759e84dbd4485807a18829188abf1786ec4e"
+source = "git+https://github.com/alexcrichton/curl-rust.git?branch=main#16133f713af1e5493a5141b87edb939343d7ee73"
 dependencies = [
  "cc",
  "libc",
@@ -175,7 +173,6 @@ dependencies = [
  "chrono",
  "clap",
  "curl",
- "curl-sys",
  "vergen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-curl = { git="https://github.com/alexcrichton/curl-rust.git", branch = "main" }
+curl = { git = "https://github.com/alexcrichton/curl-rust.git", rev = "16133f713af1e5493a5141b87edb939343d7ee73" }
 clap = { version = "3", features = ["derive"] }
 chrono = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-curl = "0.4"
-curl-sys = "0.4"
+curl = { git="https://github.com/alexcrichton/curl-rust.git", branch = "main" }
 clap = { version = "3", features = ["derive"] }
 chrono = "0.4"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use chrono::{DateTime, Utc};
 use clap::Parser;
 use curl::easy::{Easy, HttpVersion, List, ReadError};
-use curl_sys::{curl_easy_setopt, CURLoption};
-
-const CURLOPT_HTTP09_ALLOWED: CURLoption = 285;
 
 #[derive(Debug, Parser)]
 #[clap(name = "ntripping", about = "NTRIP command line client.", version = env!("VERGEN_SEMVER_LIGHTWEIGHT"))]
@@ -93,8 +90,7 @@ fn main() -> Result<()> {
         curl.put(true)?;
         curl.custom_request("GET")?;
         curl.http_version(HttpVersion::Any)?;
-
-        unsafe { curl_easy_setopt(curl.raw(), CURLOPT_HTTP09_ALLOWED, 1) };
+        curl.http_09_allowed(true)?;
 
         if opt.verbose {
             curl.verbose(true)?;


### PR DESCRIPTION
With https://github.com/alexcrichton/curl-rust/pull/447 accepted we can now get rid of the `unsafe` here!

I imagine we should just wait until the next release of the `curl` crate instead of pointing to the git repo directly.