### PR TITLE
Add username and password args

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,22 @@ The `ntripping` utility has the following usage:
     NTRIP command line client.
 
     USAGE:
-        ntripping [FLAGS] [OPTIONS]
-
-    FLAGS:
-        -h, --help       Prints help information
-        -V, --version    Prints version information
-        -v, --verbose
+        ntripping [OPTIONS]
 
     OPTIONS:
-            --client-id <client-id>     [default: 00000000-0000-0000-0000-000000000000]
-            --epoch <epoch>
-            --height <height>           [default: -5.549358852471994]
-            --lat <lat>                 [default: 37.77101999622968]
-            --lon <lon>                 [default: -122.40315159140708]
-            --url <url>                 [default: na.skylark.swiftnav.com:2101/CRS]
+            --client <CLIENT>        Client ID [default: 00000000-0000-0000-0000-000000000000]
+            --epoch <EPOCH>          Receiver time to report, as a Unix time
+        -h, --help                   Print help information
+            --height <HEIGHT>        Receiver height to report, in meters [default: -5.549358852471994]
+            --lat <LAT>              Receiver latitude to report, in degrees [default:
+                                     37.77101999622968]
+            --lon <LON>              Receiver longitude to report, in degrees [default:
+                                     -122.40315159140708]
+            --password <PASSWORD>    Password credentials
+            --url <URL>              URL of the NTRIP caster [default: na.skylark.swiftnav.com:2101/CRS]
+            --username <USERNAME>    Username credentials
+        -v, --verbose
+        -V, --version                Print version information
 
 Different resources can be requested from different locations. By default, a San
 Francisco latitude, longitude, and height will be used.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ The `ntripping` utility has the following usage:
 Different resources can be requested from different locations. By default, a San
 Francisco latitude, longitude, and height will be used.
 
+### Credentials
+
+Access credentials are usually required to access NTRIP streams. These credentials can be
+specified individually as command line arguments or directly in the URL like this
+
+```
+ntripping --url user:pass@na.skylark.swiftnav.com:2101/CRS
+```
+
 ## Copyright
 
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,14 @@ struct Cli {
 
     #[clap(long)]
     epoch: Option<u32>,
+
+    /// Username credentials
+    #[clap(long)]
+    username: Option<String>,
+
+    /// Password credentials
+    #[clap(long)]
+    password: Option<String>,
 }
 
 type Result<T> = std::result::Result<T, Box<dyn Error>>;
@@ -94,6 +102,14 @@ fn main() -> Result<()> {
 
         if opt.verbose {
             curl.verbose(true)?;
+        }
+
+        if let Some(username) = &opt.username {
+            curl.username(username)?;
+        }
+
+        if let Some(password) = &opt.password {
+            curl.password(password)?;
         }
 
         curl.write_function(|buf| Ok(io::stdout().write_all(buf).map_or(0, |_| buf.len())))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,12 +12,15 @@ use curl::easy::{Easy, HttpVersion, List, ReadError};
 #[derive(Debug, Parser)]
 #[clap(name = "ntripping", about = "NTRIP command line client.", version = env!("VERGEN_SEMVER_LIGHTWEIGHT"))]
 struct Cli {
+    /// URL of the NTRIP caster
     #[clap(long, default_value = "na.skylark.swiftnav.com:2101/CRS")]
     url: String,
 
+    /// Receiver latitude to report, in degrees
     #[clap(long, default_value = "37.77101999622968", allow_hyphen_values = true)]
     lat: String,
 
+    /// Receiver longitude to report, in degrees
     #[clap(
         long,
         default_value = "-122.40315159140708",
@@ -25,15 +28,18 @@ struct Cli {
     )]
     lon: String,
 
+    /// Receiver height to report, in meters
     #[clap(long, default_value = "-5.549358852471994", allow_hyphen_values = true)]
     height: String,
 
+    /// Client ID
     #[clap(long, default_value = "00000000-0000-0000-0000-000000000000")]
     client: String,
 
     #[clap(short, long)]
     verbose: bool,
 
+    /// Receiver time to report, as a Unix time
     #[clap(long)]
     epoch: Option<u32>,
 


### PR DESCRIPTION
This adds the option to specify the username/password credentials as a separate set of arguments to the program. It also updates the README to explain both ways to provide the credentials, either in the URL or as separate argument.