### PR TITLE
Add option to specify the GGA update period

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,10 @@ struct Cli {
     /// Password credentials
     #[clap(long)]
     password: Option<String>,
+
+    /// GGA update period, in seconds. 0 means to never send a GGA
+    #[clap(long, default_value = "10")]
+    gga_period: u64,
 }
 
 type Result<T> = std::result::Result<T, Box<dyn Error>>;
@@ -142,7 +146,7 @@ fn main() -> Result<()> {
                 let dur = now.duration_since(*last.borrow());
                 dur.unwrap_or_else(|_| Duration::from_secs(0)).as_secs()
             });
-            if elapsed > 10 {
+            if opt.gga_period > 0 && elapsed > opt.gga_period {
                 LAST.with(|last| *last.borrow_mut() = now);
                 let datetime: DateTime<Utc> = now.into();
                 let time = datetime.format("%H%M%S.00");


### PR DESCRIPTION
I needed a way to change the update period on the GGA sentences being sent up. It defaults to the same value as before, 10 seconds. I wasn't entirely sure how to handle a value of zero. The obvious options were

1. Send 1 GGA message and then never send another
2. Never send a GGA message

I ended up implementing the second. It's easier to implement, and I think it is more useful. I can see situations where we might want never send a GGA message up to the server. For physical base stations this message is entirely optional, for VRS services (and Skylark) not sending a GGA can change the behavior of the service. For sending only 1 GGA message at the beginning you can approach that behavior by setting the GGA period arbitrarily large. Maxing out a `u64` means waiting longer than the current lifetime of the universe before sending another GGA message.