### PR TITLE
Configure CRA field on 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,14 @@ struct Cli {
     /// GGA update period, in seconds. 0 means to never send a GGA
     #[clap(long, default_value = "10")]
     gga_period: u64,
+
+    /// AreaId to be used in generation of CRA message. If this flag is set, ntripping outputs messages of type CRA rather than the default CRA.
+    #[clap(long)]
+    areaid: Option<u32>,
+
+    /// SolutionID, the identifier of the connection stream to reconnect to in the event of disconnections
+    #[clap(long)]
+    sid: Option<u8>,
 }
 
 type Result<T> = std::result::Result<T, Box<dyn Error>>;
@@ -150,13 +158,32 @@ fn main() -> Result<()> {
                 LAST.with(|last| *last.borrow_mut() = now);
                 let datetime: DateTime<Utc> = now.into();
                 let time = datetime.format("%H%M%S.00");
-                let gpgga = format!(
-                    "$GPGGA,{},{:02}{:010.7},{},{:03}{:010.7},{},4,12,1.3,{:.2},M,0.0,M,1.7,0078",
-                    time, lat_deg, lat_min, lat_dir, lon_deg, lon_min, lon_dir, heightf
-                );
-                let checksum = checksum(gpgga.as_bytes());
-                let gpgga = format!("{}*{:X}\r\n", gpgga, checksum);
-                buf.write_all(gpgga.as_bytes()).unwrap();
+                
+                let message = match &opt.areaid {
+                    Some(areaid) => {
+                        // "For all other situations, the CorrectionsMask should either be omitted or set to zero whenever a CRA AreadID update is sent. In this way all corrections are sent on Skylarks regular update cycle." https://docs.google.com/document/d/10L8i-CAY3_q3UxZAIy8IQhcc-6tDeN5a/
+                        let correction_mask: u16 = 0b0;
+                        let solution_id = match &opt.sid {
+                            Some(sid) => sid.to_string(),
+                            None => String::new()
+                        };
+                        // add note to PR: trailing comma is deliberate. this field is marked "reserved"
+                        // Add note to PR: unresolved discussion related to inclusion of request_count. @jason I am working to ?
+                        format!("$PSWTCRA,{},{},{},", areaid, correction_mask, solution_id)
+                    },
+                    None => {
+                        // Add note to PR: shouldn't GGA sentences be terminated by a carriage return 
+                        // (https://docs.google.com/document/d/10L8i-CAY3_q3UxZAIy8IQhcc-6tDeN5a/edit# under "reporting position")
+                        // or more formally: 
+                        // http://www.nuovamarea.net/blog/general-sentence-format-of-nmea-0183
+                        format!("$GPGGA,{},{:02}{:010.7},{},{:03}{:010.7},{},4,12,1.3,{:.2},M,0.0,M,1.7,0078",
+                        time, lat_deg, lat_min, lat_dir, lon_deg, lon_min, lon_dir, heightf)
+                    }
+                };
+                let checksum = checksum(message.as_bytes());
+                // Add note to PR: Add '\r\n' to var 'message'? maybe write_all write_all doees not handle that...
+                let message = format!("{}*{:X}\r\n", message, checksum);
+                buf.write_all(message.as_bytes()).unwrap();
                 Ok(buf.len())
             } else {
                 Err(ReadError::Pause)


### PR DESCRIPTION
# Context

WIP flag added as the prospect of including a RequestCounter in the CRA message has not been resolved.

<!--- Background regarding what prompted this PR --->

# Description

Two new cli args are added, used to construct a CRA message.
`areaID` - if areaid is set, use CRA message instead of GGA. Populate the CRA message with the areaid value
`solutionId` sid represents the identifier of the connection stream to reconnect to in the event of disconnections

<!--- Changes proposed in this PR --->

# JIRA Reference

https://swift-nav.atlassian.net/browse/DEVINFRA-987

## resources

https://docs.google.com/document/d/10L8i-CAY3_q3UxZAIy8IQhcc-6tDeN5a/edit#heading=h.z337ya