### PR TITLE
CRA updates [SFB-265]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -162,6 +162,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +292,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +318,7 @@ dependencies = [
  "chrono",
  "clap",
  "curl",
+ "flume",
  "serde",
  "serde_yaml",
  "vergen",
@@ -453,6 +473,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +537,15 @@ checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,17 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,15 +173,6 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -240,7 +220,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "io-lifetimes",
  "rustix",
  "windows-sys",
@@ -314,7 +294,6 @@ dependencies = [
 name = "ntripping"
 version = "1.4.0"
 dependencies = [
- "atty",
  "chrono",
  "clap",
  "curl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,10 +162,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -180,6 +206,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,11 +231,17 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "io-lifetimes",
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
@@ -253,9 +295,12 @@ dependencies = [
 name = "ntripping"
 version = "1.4.0"
 dependencies = [
+ "atty",
  "chrono",
  "clap",
  "curl",
+ "serde",
+ "serde_yaml",
  "vergen",
 ]
 
@@ -392,6 +437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +471,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b5b431e8907b50339b51223b97d102db8d987ced36f6e4d03621db9316c834"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,13 +521,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -489,10 +573,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.3"
+name = "unsafe-libyaml"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ atty = "0.2"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 curl = "^0.4.44"
+flume = { version = "0.10.14", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 publish = true
 
 [dependencies]
-atty = "0.2"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 curl = "^0.4.44"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,12 @@ edition = "2018"
 publish = true
 
 [dependencies]
-curl = "^0.4.44"
-clap = { version = "4", features = ["derive"] }
+atty = "0.2"
 chrono = "0.4"
+clap = { version = "4", features = ["derive"] }
+curl = "^0.4.44"
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.9"
 
 [build-dependencies]
 vergen = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,8 @@ struct Cli {
 #[derive(Debug, Clone, Copy, serde::Deserialize)]
 struct Command {
     epoch: Option<u32>,
-    after: Option<u64>,
+    #[serde(default = "10")]
+    after: u64,
     crc: Option<u8>,
     #[serde(flatten)]
     message: Message,

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,14 +192,14 @@ impl Message {
 }
 
 fn get_commands(opt: Cli) -> Result<Box<dyn Iterator<Item = Command>>> {
-    if opt.gga_period == 0 && opt.input.is_none() {
-        return Ok(Box::new(iter::empty()));
-    }
-
     if let Some(path) = opt.input {
         let file = std::fs::File::open(path)?;
         let cmds: Vec<_> = serde_yaml::from_reader(file)?;
         return Ok(Box::new(cmds.into_iter()));
+    }
+
+    if opt.gga_period == 0 {
+        return Ok(Box::new(iter::empty()));
     }
 
     if opt.area_id.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,8 +317,8 @@ fn main() -> Result<()> {
     let handle = thread::spawn(move || {
         let commands = get_commands(opt.clone())?;
         for cmd in commands {
-            if let Some(d) = cmd.after {
-                thread::sleep(Duration::from_secs(d));
+            if cmd.after > 0 {
+                thread::sleep(Duration::from_secs(cmd.after));
             }
             if tx.send(cmd.to_bytes()).is_err() {
                 break;

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ struct Command {
 }
 
 impl Command {
-    fn to_bytes(&self) -> Vec<u8> {
+    fn to_bytes(self) -> Vec<u8> {
         let now = self.epoch.map_or_else(SystemTime::now, |e| {
             SystemTime::UNIX_EPOCH + Duration::from_secs(e.into())
         });
@@ -261,19 +261,16 @@ fn main() -> Result<()> {
     let opt = Cli::parse();
 
     let (tx, rx) = mpsc::sync_channel::<Vec<u8>>(1);
-    let ready = Arc::new(AtomicBool::new(true));
+    let ready = Arc::new(AtomicBool::new(false));
     let cmds = get_commands(&opt)?;
 
     CURL.with(|curl| -> Result<()> {
         let mut curl = curl.borrow_mut();
 
         let mut headers = List::new();
-        let mut client_header = "X-SwiftNav-Client-Id: ".to_string();
-        client_header.push_str(&opt.client_id);
-
         headers.append("Transfer-Encoding:")?;
         headers.append("Ntrip-Version: Ntrip/2.0")?;
-        headers.append(&client_header)?;
+        headers.append(&format!("X-SwiftNav-Client-Id: {}", opt.client_id))?;
 
         curl.http_headers(headers)?;
         curl.useragent("NTRIP ntrip-client/1.0")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ struct Cli {
     password: Option<String>,
 
     /// GGA update period, in seconds. 0 means to never send a GGA
-    #[arg(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 10, conflicts_with = "input")]
     gga_period: u64,
 
     /// Request counter allows correlation between message sent and acknowledgment response from corrections stream

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,90 +1,256 @@
-use std::boxed::Box;
 use std::cell::RefCell;
-use std::error::Error;
-use std::io::{self, Write};
-use std::ops::Add;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::fmt::Write;
+use std::io::{self, Write as _};
+use std::iter;
+use std::path::PathBuf;
+use std::sync::{
+    atomic::{AtomicBool, Ordering::SeqCst},
+    mpsc, Arc,
+};
+use std::thread;
+use std::time::{Duration, SystemTime};
 
 use chrono::{DateTime, Utc};
-use clap::Parser;
+use clap::{ArgGroup, Parser};
 use curl::easy::{Easy, HttpVersion, List, ReadError};
 
-#[derive(Debug, Parser)]
-#[clap(name = "ntripping", about = "NTRIP command line client.", version = env!("VERGEN_SEMVER_LIGHTWEIGHT"))]
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+thread_local! {
+    static CURL: RefCell<Easy> = RefCell::new(Easy::new());
+}
+
+#[derive(Debug, Clone, Parser)]
+#[command(
+    name = "ntripping",
+    about = "NTRIP command line client",
+    version = env!("VERGEN_SEMVER_LIGHTWEIGHT"),
+    group(
+        ArgGroup::new("gga")
+            .conflicts_with_all(["input", "cra"])
+            .args(["lat", "lon", "height"])
+            .multiple(true),
+    ),
+    group(
+        ArgGroup::new("cra")
+            .conflicts_with_all(["input", "gga"])
+            .args(["request_counter", "area_id", "corrections_mask", "solution_id"])
+            .multiple(true),
+    ),
+)]
 struct Cli {
     /// URL of the NTRIP caster
-    #[clap(long, default_value = "na.skylark.swiftnav.com:2101/CRS")]
+    #[arg(long, default_value = "na.skylark.swiftnav.com:2101/CRS")]
     url: String,
 
     /// Receiver latitude to report, in degrees
-    #[clap(long, default_value = "37.77101999622968", allow_hyphen_values = true)]
-    lat: String,
+    #[arg(long, default_value_t = 37.77101999622968, allow_hyphen_values = true)]
+    lat: f64,
 
     /// Receiver longitude to report, in degrees
-    #[clap(
-        long,
-        default_value = "-122.40315159140708",
-        allow_hyphen_values = true
-    )]
-    lon: String,
+    #[arg(long, default_value_t = -122.40315159140708, allow_hyphen_values = true)]
+    lon: f64,
 
     /// Receiver height to report, in meters
-    #[clap(long, default_value = "-5.549358852471994", allow_hyphen_values = true)]
-    height: String,
+    #[arg(long, default_value_t = -5.549358852471994, allow_hyphen_values = true)]
+    height: f64,
 
     /// Client ID
-    #[clap(
+    #[arg(
         long,
         default_value = "00000000-0000-0000-0000-000000000000",
         alias = "client"
     )]
     client_id: String,
 
-    #[clap(short, long)]
+    #[arg(short, long)]
     verbose: bool,
 
     /// Receiver time to report, as a Unix time
-    #[clap(long)]
+    #[arg(long)]
     epoch: Option<u32>,
 
     /// Username credentials
-    #[clap(long)]
+    #[arg(long)]
     username: Option<String>,
 
     /// Password credentials
-    #[clap(long)]
+    #[arg(long)]
     password: Option<String>,
 
     /// GGA update period, in seconds. 0 means to never send a GGA
-    #[clap(long, default_value = "10")]
+    #[arg(long, default_value_t = 10)]
     gga_period: u64,
 
     /// Request counter allows correlation between message sent and acknowledgment response from corrections stream
-    #[clap(long)]
+    #[arg(long)]
     request_counter: Option<u8>,
 
     /// Area ID to be used in generation of CRA message. If this flag is set, ntripping outputs messages of type CRA rather than the default GGA
-    #[clap(long)]
+    #[arg(long)]
     area_id: Option<u32>,
 
     /// Field specifying which types of corrections are to be received
-    #[clap(long)]
+    #[arg(long)]
     corrections_mask: Option<u16>,
 
     /// Solution ID, the identifier of the connection stream to reconnect to in the event of disconnections
-    #[clap(long)]
+    #[arg(long)]
     solution_id: Option<u8>,
+
+    /// Path to a YAML file containing a list of messages to send to the caster
+    #[arg(long)]
+    input: Option<PathBuf>,
 }
 
-type Result<T> = std::result::Result<T, Box<dyn Error>>;
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+struct Command {
+    epoch: Option<u32>,
+    after: Option<u64>,
+    crc: Option<u8>,
+    #[serde(flatten)]
+    message: Message,
+}
 
-thread_local! {
-    static CURL: RefCell<Easy> = RefCell::new(Easy::new());
-    static LAST: RefCell<SystemTime> = RefCell::new(UNIX_EPOCH);
+impl Command {
+    fn to_bytes(&self) -> Vec<u8> {
+        let now = self.epoch.map_or_else(SystemTime::now, |e| {
+            SystemTime::UNIX_EPOCH + Duration::from_secs(e.into())
+        });
+        let message = self.message.format(now.into());
+        let checksum = self.crc.unwrap_or_else(|| checksum(message.as_bytes()));
+        let message = format!("{message}*{checksum:X}\r\n");
+        message.into_bytes()
+    }
+}
+
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum Message {
+    Gga {
+        lat: f64,
+        lon: f64,
+        height: f64,
+    },
+    Cra {
+        request_counter: Option<u8>,
+        area_id: Option<u32>,
+        corrections_mask: Option<u16>,
+        solution_id: Option<u8>,
+    },
+}
+
+impl Message {
+    fn format(&self, time: DateTime<Utc>) -> String {
+        match *self {
+            Message::Gga { lat, lon, height } => {
+                let time = time.format("%H%M%S.00");
+
+                let latn = ((lat * 1e8).round() / 1e8).abs();
+                let lonn = ((lon * 1e8).round() / 1e8).abs();
+
+                let lat_deg = latn as u16;
+                let lon_deg = lonn as u16;
+
+                let lat_min = (latn - (lat_deg as f64)) * 60.0;
+                let lon_min = (lonn - (lon_deg as f64)) * 60.0;
+
+                let lat_dir = if lat < 0.0 { 'S' } else { 'N' };
+                let lon_dir = if lon < 0.0 { 'W' } else { 'E' };
+
+                format!(
+                    "$GPGGA,{},{:02}{:010.7},{},{:03}{:010.7},{},4,12,1.3,{:.2},M,0.0,M,1.7,0078",
+                    time, lat_deg, lat_min, lat_dir, lon_deg, lon_min, lon_dir, height
+                )
+            }
+            Message::Cra {
+                request_counter,
+                area_id,
+                corrections_mask,
+                solution_id,
+            } => {
+                let mut s = String::from("$PSWTCRA,");
+                if let Some(request_counter) = request_counter {
+                    write!(&mut s, "{request_counter}").unwrap();
+                }
+                s.push(',');
+                if let Some(area_id) = area_id {
+                    write!(&mut s, "{area_id}").unwrap();
+                }
+                s.push(',');
+                if let Some(corrections_mask) = corrections_mask {
+                    write!(&mut s, "{corrections_mask}").unwrap();
+                }
+                s.push(',');
+                if let Some(solution_id) = solution_id {
+                    write!(&mut s, "{solution_id}").unwrap();
+                }
+                s
+            }
+        }
+    }
+}
+
+fn get_commands(opt: &Cli) -> Result<Box<dyn Iterator<Item = Command> + Send>> {
+    if opt.gga_period == 0 && opt.input.is_none() {
+        return Ok(Box::new(iter::empty()));
+    }
+    match opt.clone() {
+        Cli {
+            input: Some(path), ..
+        } => {
+            let file = std::fs::File::open(path)?;
+            let cmds: Vec<_> = serde_yaml::from_reader(file)?;
+            Ok(Box::new(cmds.into_iter()))
+        }
+        opt if opt.area_id.is_some() => {
+            let first = Command {
+                epoch: opt.epoch,
+                after: None,
+                crc: None,
+                message: Message::Cra {
+                    request_counter: opt.request_counter,
+                    area_id: opt.area_id,
+                    corrections_mask: opt.corrections_mask,
+                    solution_id: opt.solution_id,
+                },
+            };
+            let it = iter::successors(Some(first), move |prev| {
+                let mut next = *prev;
+                next.after = Some(opt.gga_period);
+                if let Message::Cra {
+                    request_counter: Some(ref mut counter),
+                    ..
+                } = &mut next.message
+                {
+                    *counter = counter.wrapping_add(1);
+                }
+                Some(next)
+            });
+            Ok(Box::new(it))
+        }
+        opt => {
+            let first = Command {
+                epoch: opt.epoch,
+                after: None,
+                crc: None,
+                message: Message::Gga {
+                    lat: opt.lat,
+                    lon: opt.lon,
+                    height: opt.height,
+                },
+            };
+            let rest = iter::repeat(Command {
+                after: Some(opt.gga_period),
+                ..first
+            });
+            Ok(Box::new(iter::once(first).chain(rest)))
+        }
+    }
 }
 
 fn checksum(buf: &[u8]) -> u8 {
-    let mut sum: u8 = 0;
+    let mut sum = 0;
     for c in &buf[1..] {
         sum ^= c;
     }
@@ -94,23 +260,9 @@ fn checksum(buf: &[u8]) -> u8 {
 fn main() -> Result<()> {
     let opt = Cli::parse();
 
-    let latf: f64 = opt.lat.parse::<f64>()?;
-    let lonf: f64 = opt.lon.parse::<f64>()?;
-    let heightf: f64 = opt.height.parse::<f64>()?;
-
-    let latn = ((latf * 1e8).round() / 1e8).abs();
-    let lonn = ((lonf * 1e8).round() / 1e8).abs();
-
-    let lat_deg: u16 = latn as u16;
-    let lon_deg: u16 = lonn as u16;
-
-    let lat_min: f64 = (latn - (lat_deg as f64)) * 60.0;
-    let lon_min: f64 = (lonn - (lon_deg as f64)) * 60.0;
-
-    let lat_dir = if latf < 0.0 { 'S' } else { 'N' };
-    let lon_dir = if lonf < 0.0 { 'W' } else { 'E' };
-
-    let mut request_counter = opt.request_counter.unwrap_or(0);
+    let (tx, rx) = mpsc::sync_channel::<Vec<u8>>(1);
+    let ready = Arc::new(AtomicBool::new(true));
+    let cmds = get_commands(&opt)?;
 
     CURL.with(|curl| -> Result<()> {
         let mut curl = curl.borrow_mut();
@@ -146,60 +298,58 @@ fn main() -> Result<()> {
 
         curl.write_function(|buf| Ok(io::stdout().write_all(buf).map_or(0, |_| buf.len())))?;
 
-        curl.progress_function(|_dltot, _dlnow, _ultot, _ulnow| {
-            let now = SystemTime::now();
-            let elapsed = LAST.with(|last| {
-                let dur = now.duration_since(*last.borrow());
-                dur.unwrap_or_else(|_| Duration::from_secs(0)).as_secs()
-            });
-            if elapsed > 10 {
-                CURL.with(|curl| curl.borrow().unpause_read().unwrap());
+        curl.progress_function({
+            let ready = Arc::clone(&ready);
+            move |_dltot, _dlnow, _ultot, _ulnow| {
+                if ready.swap(false, SeqCst) {
+                    if let Err(e) = CURL.with(|curl| curl.borrow().unpause_read()) {
+                        eprintln!("unpause error: {e}");
+                        return false;
+                    }
+                }
+                true
             }
-            true
         })?;
 
         curl.read_function(move |mut buf: &mut [u8]| {
-            let now = if let Some(epoch) = opt.epoch {
-                SystemTime::UNIX_EPOCH.add(Duration::from_secs(epoch.into()))
-            } else {
-                SystemTime::now()
+            let Ok(bytes) = rx.try_recv() else {
+                return Err(ReadError::Pause);
             };
-            let elapsed = LAST.with(|last| {
-                let dur = now.duration_since(*last.borrow());
-                dur.unwrap_or_else(|_| Duration::from_secs(0)).as_secs()
-            });
-            if opt.gga_period > 0 && elapsed > opt.gga_period {
-                LAST.with(|last| *last.borrow_mut() = now);
-                let datetime: DateTime<Utc> = now.into();
-                let time = datetime.format("%H%M%S.00");
-                let message = match &opt.area_id {
-                    Some(area_id) => {
-                        let corrections_mask = &opt.corrections_mask.unwrap_or(0);
-                        let solution_id = match &opt.solution_id {
-                            Some(solution_id) => solution_id.to_string(),
-                            None => String::new()
-                        };
-                        format!("$PSWTCRA,{},{},{},{}", request_counter, area_id, corrections_mask, solution_id)
-                    },
-                    None => {
-                        format!("$GPGGA,{},{:02}{:010.7},{},{:03}{:010.7},{},4,12,1.3,{:.2},M,0.0,M,1.7,0078",
-                        time, lat_deg, lat_min, lat_dir, lon_deg, lon_min, lon_dir, heightf)
-                    }
-                };
-                request_counter = request_counter.overflowing_add(1).0;
-                let checksum = checksum(message.as_bytes());
-                let message = format!("{}*{:X}\r\n", message, checksum);
-                buf.write_all(message.as_bytes()).unwrap();
-                Ok(buf.len())
-            } else {
-                Err(ReadError::Pause)
+            if let Err(e) = buf.write_all(&bytes) {
+                eprintln!("write error: {e}");
+                return Err(ReadError::Abort);
             }
+            Ok(bytes.len())
         })?;
 
         Ok(())
     })?;
 
-    CURL.with(|curl| -> Result<()> { Ok(curl.borrow().perform()?) })?;
+    if atty::is(atty::Stream::Stdin) {
+        thread::spawn(move || {
+            for cmd in cmds {
+                if let Some(d) = cmd.after {
+                    thread::sleep(Duration::from_secs(d));
+                }
+                if tx.send(cmd.to_bytes()).is_err() {
+                    break;
+                }
+                ready.store(true, SeqCst);
+            }
+        });
+    } else {
+        thread::spawn(move || {
+            let stdin = io::stdin().lock();
+            for line in io::BufRead::lines(stdin) {
+                if tx.send(line.unwrap().into_bytes()).is_err() {
+                    break;
+                }
+                ready.store(true, SeqCst);
+            }
+        });
+    };
+
+    CURL.with(|curl| curl.borrow().perform())?;
 
     Ok(())
 }


### PR DESCRIPTION
Allows users to input GGAs/CRAs via a yaml file like

```yaml
- gga: { lat: 37.77, lon: -122.40, height: -5.54 }
- after: 30
  gga: { lat: 38.77, lon: -122.40, height: -5.54 }
```

where the first gets sent immediately and the second gets sent 30 seconds after the first ~Also added the option to read input from stdin. I'm thinking if there is something you wanna check that the tool doesn't cover as a last resort you can write a script to generate the request body but still have ntripping take care of the connection part. Not sure if that will actually be useful but it was easy to add~