### PR TITLE
Added handling of an error to make the message printed to the user nicer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,7 @@ fn get_commands(opt: Cli) -> Result<Box<dyn Iterator<Item = Command> + Send>> {
     }
 }
 
-fn main() -> Result<()> {
+fn run() -> Result<()> {
     let opt = Cli::parse();
 
     let mut curl = Easy::new();
@@ -373,5 +373,11 @@ fn main() -> Result<()> {
     } else {
         // an error stopped the thread early
         handle.join().unwrap()
+    }
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {e}");
     }
 }


### PR DESCRIPTION
I often times get various errors when running `ntripping` and have noticed that the error object's debug representation is printed when `main` returns an error. This debug representation is fine for people familiar with rust, but a more human readable output is preferable.

Before you would get error output like
```
Error: Error { description: "Couldn't resolve host name", code: 6, extra: Some("Could not resolve host: example.com") }
```

With these changes that error message becomes
```
Error: [6] Couldn't resolve host name (Could not resolve host: example.com)
```