### PR TITLE
Add option to convert position into Area ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +310,7 @@ dependencies = [
 name = "ntripping"
 version = "1.6.1"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 publish = true
 
 [dependencies]
+anyhow = "1.0.75"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 curl = "^0.4.44"

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,7 +250,7 @@ fn build_gga(opt: &Cli) -> Command {
 struct AreaIDParams {
     a: f32,
     b: f32,
-    offset: i32,
+    offset: f32,
 }
 
 fn get_area_id_parameters(lat: f32) -> AreaIDParams {
@@ -258,19 +258,19 @@ fn get_area_id_parameters(lat: f32) -> AreaIDParams {
         AreaIDParams {
             a: 0.04,
             b: 0.02,
-            offset: 0,
+            offset: 0.,
         }
     } else if lat > -60.0 && lat <= 60.0 {
         AreaIDParams {
             a: 0.02,
             b: 0.02,
-            offset: -6750000,
+            offset: -6_750_000.,
         }
     } else if lat > -75.0 && lat <= -60.0 {
         AreaIDParams {
             a: 0.04,
             b: 0.02,
-            offset: 54000000,
+            offset: 54_000_000.,
         }
     } else {
         unimplemented!("Invalid latitude {lat}")
@@ -280,9 +280,9 @@ fn get_area_id_parameters(lat: f32) -> AreaIDParams {
 fn area_id(lat: f32, lon: f32) -> u32 {
     let params = get_area_id_parameters(lat);
 
-    ((360.0 / params.a) * (75.0 - lat) / params.b) as u32
-        + ((lon + 180.0) / params.a) as u32
-        + params.offset as u32
+    (((360.0 / params.a) * (75.0 - lat) / params.b).trunc()
+        + ((lon + 180.0) / params.a).trunc()
+        + params.offset) as u32
 }
 
 fn get_commands(opt: Cli) -> Result<Box<dyn Iterator<Item = Command> + Send>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 use std::thread;
 use std::time::{Duration, SystemTime};
 
+use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use clap::{ArgGroup, Parser};
 use curl::easy::{Easy, HttpVersion, List, ReadError};
@@ -323,6 +324,14 @@ fn get_commands(opt: Cli) -> Result<Box<dyn Iterator<Item = Command> + Send>> {
 
 fn run() -> Result<()> {
     let opt = Cli::parse();
+
+    if opt.lat < -90.0 || opt.lat > 90.0 {
+        return Err(anyhow!("Invalid latitude of {}", opt.lat).into());
+    }
+
+    if opt.lon < -180.0 || opt.lon > 180.0 {
+        return Err(anyhow!("Invalid longitude of {}", opt.lon).into());
+    }
 
     let mut curl = Easy::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,15 +39,15 @@ struct Cli {
 
     /// Receiver latitude to report, in degrees
     #[arg(long, default_value_t = 37.77101999622968, allow_hyphen_values = true)]
-    lat: f64,
+    lat: f32,
 
     /// Receiver longitude to report, in degrees
     #[arg(long, default_value_t = -122.40315159140708, allow_hyphen_values = true)]
-    lon: f64,
+    lon: f32,
 
     /// Receiver height to report, in meters
     #[arg(long, default_value_t = -5.549358852471994, allow_hyphen_values = true)]
-    height: f64,
+    height: f32,
 
     /// Client ID
     #[arg(
@@ -149,9 +149,9 @@ fn checksum(buf: &[u8]) -> u8 {
 #[serde(rename_all = "lowercase")]
 enum Message {
     Gga {
-        lat: f64,
-        lon: f64,
-        height: f64,
+        lat: f32,
+        lon: f32,
+        height: f32,
     },
     Cra {
         request_counter: Option<u8>,
@@ -173,8 +173,8 @@ impl Message {
                 let lat_deg = latn as u16;
                 let lon_deg = lonn as u16;
 
-                let lat_min = (latn - (lat_deg as f64)) * 60.0;
-                let lon_min = (lonn - (lon_deg as f64)) * 60.0;
+                let lat_min = (latn - (lat_deg as f32)) * 60.0;
+                let lon_min = (lonn - (lon_deg as f32)) * 60.0;
 
                 let lat_dir = if lat < 0.0 { 'S' } else { 'N' };
                 let lon_dir = if lon < 0.0 { 'W' } else { 'E' };

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,16 +281,16 @@ fn get_area_id_parameters(lat: f32) -> AreaIDParams {
 fn area_id(lat: f32, lon: f32) -> u32 {
     let cast_to_u32 = |x: f32| -> u32 {
         let x = x.trunc();
-        assert!(x >= 0.0, "tried to cast a negative float `{x}` to an u32");
-        assert!(x <= std::u32::MAX as f32, "tried to cast float `{x}` to an u32");
+        assert!(x >= 0.0, "tried to cast a negative float `{}` to an u32", x);
+        assert!(x <= std::u32::MAX as f32, "tried to cast float `{}` to an u32", x);
         assert!(!x.is_nan(), "tried to cast NaN to a u32");
         x as u32
     };
     
     let params = get_area_id_parameters(lat);
     
-    cast_to_u32((360.0 / params.a) * (75.0 - lat) / params.b))
-        + cast_to_u32((lon + 180.0) / params.a))
+    cast_to_u32((360.0 / params.a) * (75.0 - lat) / params.b)
+        + cast_to_u32((lon + 180.0) / params.a)
         + cast_to_u32(params.offset)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,11 +279,19 @@ fn get_area_id_parameters(lat: f32) -> AreaIDParams {
 }
 
 fn area_id(lat: f32, lon: f32) -> u32 {
+    let cast_to_u32 = |x: f32| -> u32 {
+        let x = x.trunc();
+        assert!(x >= 0.0, "tried to cast a negative float `{x}` to an u32");
+        assert!(x <= std::u32::MAX as f32, "tried to cast float `{x}` to an u32");
+        assert!(!x.is_nan(), "tried to cast NaN to a u32");
+        x as u32
+    };
+    
     let params = get_area_id_parameters(lat);
-
-    (((360.0 / params.a) * (75.0 - lat) / params.b).trunc()
-        + ((lon + 180.0) / params.a).trunc()
-        + params.offset) as u32
+    
+    cast_to_u32((360.0 / params.a) * (75.0 - lat) / params.b))
+        + cast_to_u32((lon + 180.0) / params.a))
+        + cast_to_u32(params.offset)
 }
 
 fn get_commands(opt: Cli) -> Result<Box<dyn Iterator<Item = Command> + Send>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,7 +258,7 @@ fn get_area_id_parameters(lat: f32) -> AreaIDParams {
         AreaIDParams {
             a: 0.04,
             b: 0.02,
-            offset: 0
+            offset: 0,
         }
     } else if lat > -60.0 && lat <= 60.0 {
         AreaIDParams {
@@ -280,7 +280,9 @@ fn get_area_id_parameters(lat: f32) -> AreaIDParams {
 fn area_id(lat: f32, lon: f32) -> u32 {
     let params = get_area_id_parameters(lat);
 
-    ((360.0 / params.a) * (75.0 - lat) / params.b) as u32 + ((lon + 180.0) / params.a) as u32 + params.offset as u32
+    ((360.0 / params.a) * (75.0 - lat) / params.b) as u32
+        + ((lon + 180.0) / params.a) as u32
+        + params.offset as u32
 }
 
 fn get_commands(opt: Cli) -> Result<Box<dyn Iterator<Item = Command> + Send>> {


### PR DESCRIPTION
This adds another command line flag to automatically convert the given position into an Area ID (`--pos-to-area-id`). If either this new flag or the `--area-id` argument are given then the CRA message with Area ID is sent. I also changed several of the uses of `f64` to use `f32` instead to make sure there weren't rounding issues in the Area ID calculations.

Is this an acceptable way to squeeze in this functionality? I was also thinking about adding these functions into https://github.com/swift-nav/swiftnav-rs, but that's not a dependency for ntripping and would potentially complicate the portability since it pulls in C code as well.