### PR TITLE
Add debug output and no ephemeris option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,11 +57,11 @@ struct Cli {
     )]
     client_id: String,
 
-    // Enable verbose curl output
+    /// Enable verbose curl output
     #[arg(short, long)]
     verbose: bool,
 
-    // Enable curl debug output
+    /// Enable curl debug output
     #[arg(short, long)]
     debug: bool,
 
@@ -110,6 +110,7 @@ struct Cli {
     #[arg(long)]
     input: Option<PathBuf>,
 
+    /// Request that no ephemeris is sent on connection
     #[arg(long)]
     no_eph: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,9 @@ struct Cli {
     /// Path to a YAML file containing a list of messages to send to the caster
     #[arg(long)]
     input: Option<PathBuf>,
+
+    #[arg(long)]
+    no_eph: bool
 }
 
 #[derive(Debug, Clone, Copy, serde::Deserialize)]
@@ -296,6 +299,10 @@ fn run() -> Result<()> {
         } else {
             headers.append(&format!("Ntrip-GGA: {}", build_gga(&opt)))?;
         }
+    }
+
+    if opt.no_eph {
+        headers.append("X-No-Ephemerides-On-Connection: True")?;
     }
 
     curl.http_headers(headers)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,8 +57,13 @@ struct Cli {
     )]
     client_id: String,
 
+    // Enable verbose curl output
     #[arg(short, long)]
     verbose: bool,
+
+    // Enable curl debug output
+    #[arg(short, long)]
+    debug: bool,
 
     /// Receiver time to report, as a Unix time
     #[arg(long)]
@@ -302,8 +307,16 @@ fn run() -> Result<()> {
     curl.http_version(HttpVersion::Any)?;
     curl.http_09_allowed(true)?;
 
-    if opt.verbose {
+    if opt.verbose || opt.debug {
         curl.verbose(true)?;
+    }
+
+    if opt.debug {
+        curl.debug_function(|info, data| {
+            eprintln!("\n-----\nDEBUG - infotype = {:?}\n-----",info);
+            let _ = io::stderr().write_all(data);
+            eprintln!("-----");
+        })?;
     }
 
     if let Some(username) = &opt.username {

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ struct Cli {
     input: Option<PathBuf>,
 
     #[arg(long)]
-    no_eph: bool
+    no_eph: bool,
 }
 
 #[derive(Debug, Clone, Copy, serde::Deserialize)]
@@ -320,7 +320,7 @@ fn run() -> Result<()> {
 
     if opt.debug {
         curl.debug_function(|info, data| {
-            eprintln!("\n-----\nDEBUG - infotype = {:?}\n-----",info);
+            eprintln!("\n-----\nDEBUG - infotype = {:?}\n-----", info);
             let _ = io::stderr().write_all(data);
             eprintln!("-----");
         })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ struct Cli {
     #[arg(short, long)]
     verbose: bool,
 
-    /// Enable curl debug output
+    /// Enable curl debug output. This implicitly enables verbose output
     #[arg(short, long)]
     debug: bool,
 


### PR DESCRIPTION
A companion PR to https://github.com/swift-nav/pings/pull/7 which adds the same two options:
 * `--debug` is similar to `--verbose` but includes the cURL info type. This makes it a bit easier to decipher what the verbose data represents
 * `--no-eph` which includes a header requesting that no ephemeris is sent down on connection