### PR TITLE
Change workflows to use macos-latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
       - test
     strategy:
       matrix:
-        os: [windows-2019, macos-11, ubuntu-20.04]
+        os: [windows-2019, macos-latest, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,10 +24,10 @@ jobs:
           - os: windows-2019
             binary_target: x86_64-pc-windows-msvc
             profile: release+windows
-          - os: macos-11
+          - os: macos-latest
             binary_target: x86_64-apple-darwin
             profile: release+mac_intel
-          - os: macos-11
+          - os: macos-latest
             binary_target: aarch64-apple-darwin
             profile: release+mac_arm
 


### PR DESCRIPTION
We've got several Dependabot PRs blocked since they can't build the macOS stage. This PR updates the macOS image used by the workflows to use `macos-latest` instead of specifying a certain version.

Note: It looks like we can update the Windows image used, as well as the Ubuntu image. Do we want to do that as well?