### PR TITLE
Update Dependabot to ignore patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     time: "13:00"
   open-pull-requests-limit: 10
   reviewers:
-    - "jbangelo"
+    - "swift-nav/open-source"
   ignore:
   - dependency-name: curl
     versions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,20 @@ updates:
     interval: daily
     time: "13:00"
   open-pull-requests-limit: 10
+  reviewers:
+    - "jbangelo"
   ignore:
+  # Ignore patch updates for all
+  - dependency-name: "*"
+    update-types: ["version-update:semver-patch"]
+  # Keep vergen at our pinned version
   - dependency-name: vergen
     versions:
     - "> 3.2.0"
   - dependency-name: vergen
     versions:
     - ">= 4.a, < 5"
+  # Skip over this version of curl
   - dependency-name: curl
     versions:
     - 0.4.36

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
   reviewers:
     - "jbangelo"
   ignore:
-  # Ignore patch updates for all
-  - dependency-name: "*"
-    update-types: ["version-update:semver-patch"]
   # Keep vergen at our pinned version
   - dependency-name: vergen
     versions:
@@ -23,3 +20,6 @@ updates:
   - dependency-name: curl
     versions:
     - 0.4.36
+  # Ignore patch updates for all
+  - dependency-name: "*"
+    update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
We tend to get a bunch of patch updates to dependencies , which can create a lot of pointless noise in the commit history. Since we have security scans enabled, it should be fine to skip over patch updates until we see encounter a bug that requires an update.

This also adds a reviewer to the Dependabot PRs, so that we can get them reviewed and merged in a timely fashion.